### PR TITLE
Updates node version from 12 to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ outputs:
   books:
     description: "stringified JSON of fetched books"
 runs:
-  using: "node12"
+  using: "node20"
   main: "dist/index.js"
 branding:
   icon: "book"


### PR DESCRIPTION
Both node 12 and node 16 have reached end of life and updating to 20 will suppress the associated workflow warnings.

See also:

https://github.com/nodejs/Release/#end-of-life-releases
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/